### PR TITLE
Remove colon after "contains"

### DIFF
--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -5920,7 +5920,7 @@ xref: TermSpec: "none"
 xref: UniMod: "UniMod:55"
 is_a: MOD:00905 ! modified L-cysteine residue
 is_a: MOD:01862 ! disulfide conjugated residue
-relationship: contains: MOD:02026 ! S-(cysteinyl-glycyl)-L-cysteine
+relationship: contains MOD:02026 ! S-(cysteinyl-glycyl)-L-cysteine
 
 [Term]
 id: MOD:00235


### PR DESCRIPTION
We made this fix locally at PomBase to allow our parser to read the OBO file.

@ValWood
