### PR TITLE
Trimethylation not on N-term

### DIFF
--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -15381,7 +15381,7 @@ xref: MassAvg: "none"
 xref: MassMono: "none"
 xref: Origin: "X"
 xref: Source: "natural"
-xref: TermSpec: "N-term"
+xref: TermSpec: "none"
 is_a: MOD:00430 ! trimethylated residue
 
 [Term]


### PR DESCRIPTION
As MOD:00083 (N6,N6,N6-trimethyl-L-lysine) has a TermSpec of 'none' and does not occur on a terminus, its parent nodes should either have no TermSpec set or should have a value of 'none'. This is not the case with parent node MOD:00711 (trimethylated protonated-residue) which currently has a TermSpec of 'N-term'. In earlier consultation with @pmt706, he seemed to think this was the right change to make.