### PR TITLE
Adding glycans for SARS-CoV-2 as requested

### DIFF
--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-date: 24:11:2020 15:23
+date: 03:12:2020 14:14
 saved-by: Paul M. Thomas
 subsetdef: PSI-MOD-slim "subset of protein modifications"
 synonymtypedef: DeltaMass-label "Label from MS DeltaMass" EXACT
@@ -16,9 +16,9 @@ synonymtypedef: Unimod-description "Description (full_name) from Unimod" RELATED
 synonymtypedef: Unimod-interim "Interim label from Unimod" RELATED
 synonymtypedef: UniProt-feature "Protein feature description from UniProtKB" EXACT
 default-namespace: PSI-MOD
-remark: PSI-MOD version: 1.019.0
+remark: PSI-MOD version: 1.021.0
 remark: RESID release: 75.00
-remark: ISO-8601 date: 2020-11-24 15:23Z
+remark: ISO-8601 date: 2020-12-03 14:14Z
 remark: Annotation note 1 - "[PSI-MOD:ref]" has been replaced by PubMed:18688235.
 remark: Annotation note 2 - When an entry in the RESID Database is annotated with different sources because the same modification can arise from different encoded amino acids, then the PSI-MOD definition for each different source instance carries the RESID cross-reference followed by a hash symbol "#" and a 3 or 4 character label. When an entry in the RESID Database is annotated as a general modification with the same enzymatic activity producing different chemical structures depending on natural variation in the nonproteinaceous substrate, on secondary modifications that do not change the nature of the primary modification, or on a combination of a primary and one or more secondary modifications on the same residue, then the PSI-MOD definition for each different instance carries the RESID cross-reference followed by the special tag "#var".
 remark: Annotation note 3 - When an entry in the Unimod database is annotated as a general modification, and one or more instance sites are listed, then the PSI-MOD definition for each different site instance carries the Unimod cross-reference followed by a hash symbol and an amino acid code, "N-term" or "C-term".

--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -39859,6 +39859,132 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:00915 ! modified L-proline residue
 
+[Term]
+id: MOD:02031
+name: dHex1Hex4HexNAc5
+def: "modification from Unimod N-linked glycosylation, dHex Hex(4) HexNAc(5)" [PubMed:33135055, Unimod:1519]
+synonym: "dHex Hex(4) HexNAc(5)" RELATED Unimod-description []
+xref: DiffAvg: "1810.68"
+xref: DiffFormula: "C 70 H 115 N 5 O 49"
+xref: DiffMono: "1809.666065"
+xref: Formula: "C 74 H 121 N 7 O 51"
+xref: MassAvg: "1924.78"
+xref: MassMono: "1923.708993"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1519"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00903 ! modified L-asparagine residue
+
+[Term]
+id: MOD:02032
+name: dHex2Hex4HexNAc5
+def: "modification from Unimod N-linked glycosylation, dHex(2) Hex(4) HexNAc(5)" [PubMed:33135055, Unimod:1785]
+synonym: "dHex(2) Hex(4) HexNAc(5)" RELATED Unimod-description []
+xref: DiffAvg: "1956.82"
+xref: DiffFormula: "C 76 H 125 N 5 O 53"
+xref: DiffMono: "1955.723974"
+xref: Formula: "C 80 H 131 N 7 O 55"
+xref: MassAvg: "2070.92"
+xref: MassMono: "2069.766901"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1785"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00903 ! modified L-asparagine residue
+
+[Term]
+id: MOD:02033
+name: dHex1Hex5HexNAc3
+def: "modification from Unimod N-linked glycosylation, dHex Hex(5) HexNAc(3)" [PubMed:33135055, Unimod:1484]
+synonym: "dHex Hex(5) HexNAc(3)" RELATED Unimod-description []
+xref: DiffAvg: "1566.43"
+xref: DiffFormula: "C 60 H 99 N 3 O 44"
+xref: DiffMono: "1565.560143"
+xref: Formula: "C 64 H 105 N 5 O 46"
+xref: MassAvg: "1680.53"
+xref: MassMono: "1679.603071"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1484"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00903 ! modified L-asparagine residue
+
+[Term]
+id: MOD:02034
+name: dHex1Hex3HexNAc6
+def: "modification from Unimod N-linked glycosylation, dHex Hex(3) HexNAc(6)" [PubMed:33135055, Unimod:1781]
+synonym: "dHex Hex(3) HexNAc(6)" RELATED Unimod-description []
+xref: DiffAvg: "1851.73"
+xref: DiffFormula: "C 72 H 118 N 6 O 49"
+xref: DiffMono: "1850.692614"
+xref: Formula: "C 76 H 124 N 8 O 51"
+xref: MassAvg: "1965.83"
+xref: MassMono: "1964.735542"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1781"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00903 ! modified L-asparagine residue
+
+[Term]
+id: MOD:02035
+name: dHex1Hex6HexNAc3
+def: "modification from Unimod N-linked glycosylation, dHex Hex(6) HexNAc(3)" [PubMed:33135055, Unimod:1509]
+synonym: "dHex Hex(6) HexNAc(3)" RELATED Unimod-description []
+xref: DiffAvg: "1728.57"
+xref: DiffFormula: "C 66 H 109 N 3 O 49"
+xref: DiffMono: "1727.612967"
+xref: Formula: "C 70 H 115 N 5 O 51"
+xref: MassAvg: "1842.67"
+xref: MassMono: "1841.655894"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1509"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00903 ! modified L-asparagine residue
+
+[Term]
+id: MOD:02036
+name: Hex9HexNAc2
+def: "modification from Unimod N-linked glycosylation, Hex(9)HexNAc(2)" [PubMed:33135055, Unimod:1531]
+synonym: "M9/Man9" RELATED Unimod-description []
+xref: DiffAvg: "1865.66"
+xref: DiffFormula: "C 70 H 116 N 2 O 55"
+xref: DiffMono: "1864.634156"
+xref: Formula: "C 74 H 122 N 4 O 57"
+xref: MassAvg: "1979.76"
+xref: MassMono: "1978.677083"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1531"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00903 ! modified L-asparagine residue
+
+[Term]
+id: MOD:02037
+name: Hex7HexNAc2
+def: "modification from Unimod N-linked glycosylation, Hex(7) HexNAc(2)" [PubMed:33135055, Unimod:1480]
+synonym: "M7/Man7" RELATED Unimod-description []
+xref: DiffAvg: "1541.38"
+xref: DiffFormula: "C 58 H 96 N 2 O 45"
+xref: DiffMono: "1540.528509"
+xref: Formula: "C 62 H 102 N 4 O 47"
+xref: MassAvg: "1655.48"
+xref: MassMono: "1654.571436"
+xref: Origin: "N"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:1480"
+is_a: MOD:00725 ! complex glycosylation
+is_a: MOD:00903 ! modified L-asparagine residue
+
 [Typedef]
 id: contains
 name: contains


### PR DESCRIPTION
Fixes #25

These are direct pulls from Unimod.  Masses differ VERY slightly (in the 6th decimal place), but I have used our atom table to calculate these masses and did not round until the end.