### PR TITLE
Monomethylated Histidine Fixes

### DIFF
--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-date: 03:12:2020 14:14
+date: 03:12:2020 16:58
 saved-by: Paul M. Thomas
 subsetdef: PSI-MOD-slim "subset of protein modifications"
 synonymtypedef: DeltaMass-label "Label from MS DeltaMass" EXACT
@@ -16,9 +16,9 @@ synonymtypedef: Unimod-description "Description (full_name) from Unimod" RELATED
 synonymtypedef: Unimod-interim "Interim label from Unimod" RELATED
 synonymtypedef: UniProt-feature "Protein feature description from UniProtKB" EXACT
 default-namespace: PSI-MOD
-remark: PSI-MOD version: 1.021.0
+remark: PSI-MOD version: 1.022.0
 remark: RESID release: 75.00
-remark: ISO-8601 date: 2020-12-03 14:14Z
+remark: ISO-8601 date: 2020-12-03 16:58Z
 remark: Annotation note 1 - "[PSI-MOD:ref]" has been replaced by PubMed:18688235.
 remark: Annotation note 2 - When an entry in the RESID Database is annotated with different sources because the same modification can arise from different encoded amino acids, then the PSI-MOD definition for each different source instance carries the RESID cross-reference followed by a hash symbol "#" and a 3 or 4 character label. When an entry in the RESID Database is annotated as a general modification with the same enzymatic activity producing different chemical structures depending on natural variation in the nonproteinaceous substrate, on secondary modifications that do not change the nature of the primary modification, or on a combination of a primary and one or more secondary modifications on the same residue, then the PSI-MOD definition for each different instance carries the RESID cross-reference followed by the special tag "#var".
 remark: Annotation note 3 - When an entry in the Unimod database is annotated as a general modification, and one or more instance sites are listed, then the PSI-MOD definition for each different site instance carries the Unimod cross-reference followed by a hash symbol and an amino acid code, "N-term" or "C-term".
@@ -2075,6 +2075,7 @@ xref: Origin: "H"
 xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:02038 ! monomethylated L-histidine
+is_a: MOD:00724 ! N-methylated L-histidine
 
 [Term]
 id: MOD:00083
@@ -8063,6 +8064,7 @@ xref: Origin: "H"
 xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:02038 ! monomethylated L-histidine
+is_a: MOD:00724 ! N-methylated L-histidine
 
 [Term]
 id: MOD:00323
@@ -40004,7 +40006,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 xref: Unimod: "Unimod:34"
 is_a: MOD:00599 ! monomethylated residue
-is_a: MOD:00724 ! N-methylated L-histidine
+is_a: MOD:00661 ! methylated histidine
 
 [Typedef]
 id: contains

--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -2074,7 +2074,7 @@ xref: MassMono: "151.074562"
 xref: Origin: "H"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00724 ! N-methylated L-histidine
+is_a: MOD:02038 ! monomethylated L-histidine
 
 [Term]
 id: MOD:00083
@@ -8062,7 +8062,7 @@ xref: MassMono: "151.074562"
 xref: Origin: "H"
 xref: Source: "natural"
 xref: TermSpec: "none"
-is_a: MOD:00724 ! N-methylated L-histidine
+is_a: MOD:02038 ! monomethylated L-histidine
 
 [Term]
 id: MOD:00323
@@ -39984,6 +39984,27 @@ xref: TermSpec: "none"
 xref: Unimod: "Unimod:1480"
 is_a: MOD:00725 ! complex glycosylation
 is_a: MOD:00903 ! modified L-asparagine residue
+
+[Term]
+id: MOD:02038
+name: monomethylated L-histidine
+def: "A protein modification that effectively replaces one hydrogen atom of an L-histidine residue with one methyl group." [DeltaMass:215, OMSSA:77, Unimod:34#H]
+subset: PSI-MOD-slim
+synonym: "Me1His" EXACT PSI-MOD-label []
+synonym: "Methyl" RELATED PSI-MS-label []
+synonym: "methylh" EXACT OMSSA-label []
+xref: DiffAvg: "14.03"
+xref: DiffFormula: "C 1 H 2 N 0 O 0"
+xref: DiffMono: "14.015650"
+xref: Formula: "C 7 H 9 N 3 O 1"
+xref: MassAvg: "151.17"
+xref: MassMono: "151.074562"
+xref: Origin: "H"
+xref: Source: "natural"
+xref: TermSpec: "none"
+xref: Unimod: "Unimod:34"
+is_a: MOD:00599 ! monomethylated residue
+is_a: MOD:00724 ! N-methylated L-histidine
 
 [Typedef]
 id: contains


### PR DESCRIPTION
There exists a problem where UniProt's ptmlist points to an incorrect entry because the correct entry did not exist in PSI-MOD.  This is described in detail in #20.  This PR closes #20.