### PR TITLE
Fix part_of relationship syntax

### DIFF
--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -40346,7 +40346,7 @@ xref: Source: "natural"
 xref: TermSpec: "none"
 is_a: MOD:00905 ! modified L-cysteine residue
 is_a: MOD:01862 ! disulfide conjugated residue
-relationship: part_of: MOD:00234 ! L-cysteine glutathione disulfide
+relationship: part_of MOD:00234 ! L-cysteine glutathione disulfide
 
 [Term]
 id: MOD:02027


### PR DESCRIPTION
There's an extra colon in the "relationship: ..." line.