### PR TITLE
Add workflow to trigger browser deployment on update

### DIFF
--- a/.github/workflows/trigger-browser-deployment.yml
+++ b/.github/workflows/trigger-browser-deployment.yml
@@ -1,0 +1,19 @@
+name: Trigger browser deployment on PSI-MOD.obo Update
+on:
+    push:
+        paths:
+            - "PSI-MOD.obo"
+        branches:
+            - master
+
+jobs:
+    trigger-browser-deployment:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Trigger psi-mod-browser deployment
+              run: |
+                  curl -X POST \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    -H "Authorization: token ${{ secrets.PSI_MOD_BROWSER_PAT }}" \
+                    https://api.github.com/repos/HUPO-PSI/psi-mod-browser/dispatches \
+                    -d '{"event_type":"psi-mod-updated"}'


### PR DESCRIPTION
This workflow is required to trigger a deployment of the new modification browser (now at https://github.com/HUPO-PSI/psi-mod-browser)