### PR TITLE
Clean up remarks

### DIFF
--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
 ontology: mod
 date: 22:05:2026 18:00
-data-version: 1.034.0
+data-version: 1.035.0
 saved-by: Douwe Schulte
 subsetdef: PSI-MOD-slim "subset of protein modifications"
 synonymtypedef: DeltaMass-label "Label from MS DeltaMass" EXACT

--- a/PSI-MOD.obo
+++ b/PSI-MOD.obo
@@ -1,7 +1,8 @@
 format-version: 1.2
 ontology: mod
-date: 22:05:2026 17:00
-saved-by: Patrick Garrett
+date: 22:05:2026 18:00
+data-version: 1.034.0
+saved-by: Douwe Schulte
 subsetdef: PSI-MOD-slim "subset of protein modifications"
 synonymtypedef: DeltaMass-label "Label from MS DeltaMass" EXACT
 synonymtypedef: OMSSA-label "Short label from OMSSA" EXACT
@@ -17,10 +18,7 @@ synonymtypedef: Unimod-description "Description (full_name) from Unimod" RELATED
 synonymtypedef: Unimod-interim "Interim label from Unimod" RELATED
 synonymtypedef: UniProt-feature "Protein feature description from UniProtKB" EXACT
 default-namespace: PSI-MOD
-data-version: 1.034.0
-remark: PSI-MOD version: 1.034.0
 remark: RESID release: 75.00
-remark: ISO-8601 date: 2022-06-13 12:12Z
 remark: Annotation note 01 - "[PSI-MOD:ref]" has been replaced by PubMed:18688235.
 remark: Annotation note 02 - When an entry in the RESID Database is annotated with different sources because the same modification can arise from different encoded amino acids, then the PSI-MOD definition for each different source instance carries the RESID cross-reference followed by a hash symbol "#" and a 3 or 4 character label. When an entry in the RESID Database is annotated as a general modification with the same enzymatic activity producing different chemical structures depending on natural variation in the nonproteinaceous substrate, on secondary modifications that do not change the nature of the primary modification, or on a combination of a primary and one or more secondary modifications on the same residue, then the PSI-MOD definition for each different instance carries the RESID cross-reference followed by the special tag "#var".
 remark: Annotation note 03 - When an entry in the Unimod database is annotated as a general modification, and one or more instance sites are listed, then the PSI-MOD definition for each different site instance carries the Unimod cross-reference followed by a hash symbol and an amino acid code, "N-term" or "C-term".


### PR DESCRIPTION
Remove some outdated remarks and cluster the lines that need to be changed for a version bump.

- The duplicated version remark is outside of the Obo spec and parsers should use `data-version`.
- The old timestamp remark is outdated and parsers should use `date`.
- Clustering the three lines that need to be changed for a new version should make it easier to update these values and not miss one, plus the reordering should not change behaviour for any Obo parsers as the order of the header fields is not specified.